### PR TITLE
Feat: 웹캠 페이지 감정 실시간 차트화

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,74 +3,77 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^13.5.0",
-        "@types/jest": "^29.4.0",
-        "@types/node": "^18.13.0",
-        "@types/react": "^18.0.27",
-        "@types/react-dom": "^18.0.10",
-        "@types/react-redux": "^7.1.25",
-        "@types/styled-components": "^5.1.26",
-        "@typescript-eslint/parser": "^5.51.0",
-        "typescript": "^4.9.5"
-    },
-    "dependencies": {
-        "@emotion/react": "^11.10.5",
-        "@emotion/styled": "^11.10.5",
-        "@mui/icons-material": "^5.11.0",
-        "@mui/joy": "^5.0.0-alpha.66",
-        "@mui/material": "^5.11.7",
-        "@mui/styled-engine-sc": "^5.11.0",
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^13.5.0",
-        "@types/react-slick": "^0.23.10",
-        "antd": "^5.1.7",
-        "axios": "^1.3.2",
-        "bootstrap": "^5.2.3",
-        "face-api.js": "^0.22.2",
-        "react": "^18.2.0",
-        "react-bootstrap": "^2.7.0",
-        "react-dom": "^18.2.0",
-        "react-icons": "^4.7.1",
-        "react-minimal-side-navigation": "^1.9.2",
-        "react-modal": "^3.16.1",
-        "react-router-dom": "^6.8.0",
-        "react-scripts": "5.0.1",
-        "react-slick": "^0.29.0",
-        "react-transition-group": "^4.4.5",
-        "react-webcam": "^7.0.1",
-        "semantic-ui-css": "^2.5.0",
-        "semantic-ui-react": "^2.1.4",
-        "slick-carousel": "^1.8.1",
-        "styled-components": "^5.3.6",
-        "web-vitals": "^2.1.4",
-        "webm-to-mp4": "^1.0.0"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject",
-        "install:clean": "rm -rf node_modules && rm -rf package-lock.json"
-    },
-    "eslintConfig": {
-        "extends": [
-            "react-app",
-            "react-app/jest"
-        ]
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^29.4.0",
+    "@types/node": "^18.13.0",
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
+    "@types/react-redux": "^7.1.25",
+    "@types/styled-components": "^5.1.26",
+    "@typescript-eslint/parser": "^5.51.0",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.0",
+    "@mui/joy": "^5.0.0-alpha.66",
+    "@mui/material": "^5.11.7",
+    "@mui/styled-engine-sc": "^5.11.0",
+    "@reduxjs/toolkit": "^1.9.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/react-slick": "^0.23.10",
+    "antd": "^5.1.7",
+    "axios": "^1.3.2",
+    "bootstrap": "^5.2.3",
+    "face-api.js": "^0.22.2",
+    "react": "^18.2.0",
+    "react-bootstrap": "^2.7.0",
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.7.1",
+    "react-minimal-side-navigation": "^1.9.2",
+    "react-modal": "^3.16.1",
+    "react-redux": "^8.0.5",
+    "react-router-dom": "^6.8.0",
+    "react-scripts": "5.0.1",
+    "react-slick": "^0.29.0",
+    "react-transition-group": "^4.4.5",
+    "react-webcam": "^7.0.1",
+    "recharts": "^2.4.1",
+    "semantic-ui-css": "^2.5.0",
+    "semantic-ui-react": "^2.1.4",
+    "slick-carousel": "^1.8.1",
+    "styled-components": "^5.3.6",
+    "web-vitals": "^2.1.4",
+    "webm-to-mp4": "^1.0.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "install:clean": "rm -rf node_modules && rm -rf package-lock.json"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
 }

--- a/src/views/Contents/CamContent/CamContent.tsx
+++ b/src/views/Contents/CamContent/CamContent.tsx
@@ -9,15 +9,14 @@ const StyleContent = styled.div`
     background-color: #fff;
     font-family: GangwonEduPowerExtraBoldA;
     display: flex;
-    height: 100vh;
-    text-align: center;
+    height: auto;
+    text-align: left;
     margin-top: -16px;
 `;
-
 const WebcamPage = styled.section`
     display: block;
     text-align: center;
-    margin-left: 300px;
+    margin-left: 10px;
     margin-top: 20px;
 `;
 

--- a/src/views/webCam/Emotion.tsx
+++ b/src/views/webCam/Emotion.tsx
@@ -1,0 +1,25 @@
+import React, { PureComponent } from 'react';
+import { BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+interface datas {
+    name: string;
+    uv: number;
+}
+interface data {
+    data: datas[];
+}
+export default class Emotion extends PureComponent<data> {
+    static defaultProps = {
+        data: [{}],
+    };
+    render() {
+        return (
+            <ResponsiveContainer width="100%" height="20%">
+                <BarChart width={500} height={300} data={this.props.data}>
+                    <XAxis dataKey="name" />
+                    <Bar dataKey="uv" fill="#8884d8" />
+                </BarChart>
+            </ResponsiveContainer>
+        );
+    }
+}

--- a/src/views/webCam/index.tsx
+++ b/src/views/webCam/index.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import * as faceapi from 'face-api.js';
 import styled, { keyframes } from 'styled-components';
 import { TbLoader } from 'react-icons/tb';
+import Emotion from './Emotion';
 
 import './index.css';
 import * as types from '../../types/cam';
@@ -14,7 +15,7 @@ const rotate = keyframes`
   from {
       transform: rotate(0deg);
     }
-    
+
     to { transform: rotate(360deg);
     }
     `;
@@ -73,6 +74,37 @@ function WebCamPage() {
 
     const [camStarted, setCamStarted] = useState(true);
     const [modelLoaded, setModelLoaded] = useState(false);
+
+    const [data, setData] = useState([
+        {
+            name: 'natural',
+            uv: 0,
+        },
+        {
+            name: 'Happy',
+            uv: 0,
+        },
+        {
+            name: 'Sad',
+            uv: 0,
+        },
+        {
+            name: 'Surprised',
+            uv: 0,
+        },
+        {
+            name: 'disgusted',
+            uv: 0,
+        },
+        {
+            name: 'angry',
+            uv: 0,
+        },
+        {
+            name: 'fearful',
+            uv: 0,
+        },
+    ]);
 
     useEffect(() => {
         // 비디오
@@ -193,6 +225,39 @@ function WebCamPage() {
                     expression.value = Math.max(...Object.values(otherDetection));
                     expression.label = Object.keys(otherDetection).find((key) => otherDetection[key] === expression.value) || ''; // 현재 최대 수치 감정 종류 가져오기
                     expression.time = Date.now();
+
+                    console.log(detection.expressions);
+
+                    setData([
+                        {
+                            name: 'natural',
+                            uv: detection.expressions.fearful,
+                        },
+                        {
+                            name: 'Happy',
+                            uv: detection.expressions.happy,
+                        },
+                        {
+                            name: 'Sad',
+                            uv: detection.expressions.sad,
+                        },
+                        {
+                            name: 'Surprised',
+                            uv: detection.expressions.surprised,
+                        },
+                        {
+                            name: 'disgusted',
+                            uv: detection.expressions.disgusted,
+                        },
+                        {
+                            name: 'angry',
+                            uv: detection.expressions.angry,
+                        },
+                        {
+                            name: 'fearful',
+                            uv: detection.expressions.fearful,
+                        },
+                    ]);
                 });
             return expression;
         };
@@ -255,33 +320,36 @@ function WebCamPage() {
     }
 
     return (
-        <div>
-            <h2>Recording My DAY</h2>
+        <>
+            <div>
+                <h2>Recording My DAY</h2>
 
-            <div
-                ref={wrapRef}
-                id="wrap"
-                style={{
-                    borderStyle: 'none',
-                    width: constraints.video.width,
-                    height: constraints.video.height,
-                }}
-            >
+                <div
+                    ref={wrapRef}
+                    id="wrap"
+                    style={{
+                        borderStyle: 'none',
+                        width: constraints.video.width,
+                        height: constraints.video.height,
+                    }}
+                >
+                    <div>
+                        {camStarted ? (
+                            <video ref={videoRef} autoPlay muted onPlay={onPlay} width={constraints.video.width} height={constraints.video.height} />
+                        ) : (
+                            <Rotate>
+                                <TbLoader size="50" style={{ padding: 0 }} />
+                            </Rotate>
+                        )}
+                    </div>
+                </div>
                 <div>
-                    {camStarted ? (
-                        <video ref={videoRef} autoPlay muted onPlay={onPlay} width={constraints.video.width} height={constraints.video.height} />
-                    ) : (
-                        <Rotate>
-                            <TbLoader size="50" style={{ padding: 0 }} />
-                        </Rotate>
-                    )}
+                    <OnButton onClick={() => setCamStarted(true)}>ON</OnButton>
+                    <OffButton onClick={() => setCamStarted(false)}>OFF</OffButton>
                 </div>
             </div>
-            <div>
-                <OnButton onClick={() => setCamStarted(true)}>ON</OnButton>
-                <OffButton onClick={() => setCamStarted(false)}>OFF</OffButton>
-            </div>
-        </div>
+            <Emotion data={data} />
+        </>
     );
 }
 


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #2  #17 [CD-99]

## **⚡ Content**

- 얼굴 감정 인식 부분 실시간 차트 추가하였습니다.

## **📆 TBD**

- 후에 인식을 '나'로 한정하게 되면 여러명이 있었을때 본인의 감정 수치와 맞는지 확인이 필요
- 현재 조금 느린데 환경이나 노트북 퍼포먼스의 문제인지 메인 노트북에서 속도 확인 필요
- 감정에 세세한 부분까지 나와서 현재 얼굴 디텍션시 라벨에 함께 나오는 감정 수치 삭제 필요

## **🌟 Point**

- 핵심 내용

## ❓ Question

- 질문


[CD-99]: https://cd-carpe-diem.atlassian.net/browse/CD-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ